### PR TITLE
 Changed dependency for Castle.Core" to  version 3.2.0

### DIFF
--- a/Nuget/ChangeTracking.nuspec
+++ b/Nuget/ChangeTracking.nuspec
@@ -14,7 +14,7 @@ By using Castle Dynamic Proxy to create proxies of your classes at runtime, you 
         <summary>Track changes in your POCO objects, and in your collections.</summary>
         <tags>ChangeTracking DynamicProxy Change Tracking POCO</tags>
         <dependencies>
-            <dependency id="Castle.Core" version="3.3.0" />
+            <dependency id="Castle.Core" version="3.2.0" />
         </dependencies>
     </metadata>
     <files>


### PR DESCRIPTION
I am no expert on Nuget packaging, however based on my deployment experience, I think this change is proper.