### PR TITLE
Support for interface-typed collections and properties

### DIFF
--- a/Source/ChangeTracking.Tests/ChangeTracking.Tests.csproj
+++ b/Source/ChangeTracking.Tests/ChangeTracking.Tests.csproj
@@ -78,6 +78,7 @@
     <Compile Include="SpeedTest.cs" />
     <Compile Include="Order.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="InterfaceListsTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ChangeTracking\ChangeTracking.csproj">

--- a/Source/ChangeTracking.Tests/ChangeTracking.Tests.csproj
+++ b/Source/ChangeTracking.Tests/ChangeTracking.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="IChangeTrackableCollectionTests.cs" />
     <Compile Include="IBindingListTests.cs" />
     <Compile Include="INotifyPropertyChangedTests.cs" />
+    <Compile Include="InterfacePropertiesTests.cs" />
     <Compile Include="IRevertibleChangeTrackingTests.cs" />
     <Compile Include="IEditableObjectTests.cs" />
     <Compile Include="IChangeTrackableTests.cs" />

--- a/Source/ChangeTracking.Tests/InterfaceListsTest.cs
+++ b/Source/ChangeTracking.Tests/InterfaceListsTest.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ChangeTracking.Tests
+{
+    [TestClass]
+    public class InterfaceListsTest
+    {
+        public class Building
+        {
+            public virtual IList<IFloor> Floors { get; set; } = new List<IFloor>();
+        }
+
+        public interface IFloor { }
+
+        public class Floor : IFloor
+        {
+        }
+
+        [TestMethod]
+        public void CanHandleInterfaceLists()
+        {
+            // Arrange
+            var b = new Building();
+            var bTrackable = b.AsTrackable();
+
+            Exception exception = null;
+            try
+            {
+                // Act
+                bTrackable.Floors.Add(new Floor());
+            }
+            catch (Exception x)
+            {
+                exception = x;
+            }
+
+            // Assert
+            Assert.IsNull(exception, "collections of interfaces are not supported?");
+
+            var bChanges = bTrackable.CastToIChangeTrackable();
+            Assert.IsTrue(bChanges.IsChanged);
+        }
+    }
+}

--- a/Source/ChangeTracking.Tests/InterfacePropertiesTests.cs
+++ b/Source/ChangeTracking.Tests/InterfacePropertiesTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ChangeTracking.Tests
+{
+    [TestClass]
+    public class InterfacePropertiesTest
+    {
+        public class Building
+        {
+            public virtual IAddress Address { get; set; }
+        }
+
+        public interface IAddress
+        {
+            string Street { get; set; }
+            IZipCode ZipCode { get; set; }
+        }
+
+        public class Address : IAddress
+        {
+            public virtual string Street { get; set; }
+            public virtual IZipCode ZipCode { get; set; }
+        }
+
+        public interface IZipCode
+        {
+            int Code { get; set; }
+        }
+
+        public class ZipCode : IZipCode
+        {
+            public virtual int Code { get; set; }
+        }
+
+        [TestMethod]
+        public void CanDetectChangesOfInterfaceProperty()
+        {
+            // Arrange
+            var b = new Building()
+            {
+                Address = new Address()
+            };
+            var bTrackable = b.AsTrackable();
+
+            // Act
+            bTrackable.Address.Street = "Duckstreet";
+
+            // Assert
+            var bChanges = bTrackable.CastToIChangeTrackable();
+            Assert.IsTrue(bChanges.IsChanged);
+        }
+
+        [TestMethod]
+        public void CanDetectChangesOfInterfaceProperty_InDeepHierarchy()
+        {
+            // Arrange
+            var b = new Building();
+            var bTrackable = b.AsTrackable();
+            bTrackable.Address = new Address() { Street = "Duckstreet 33", ZipCode = new ZipCode()};
+            bTrackable.CastToIChangeTrackable().AcceptChanges();
+
+            Exception exception = null;
+            try
+            {
+                // Act
+                bTrackable.Address.ZipCode.Code = 1232;
+            }
+            catch (Exception x)
+            {
+                exception = x;
+            }
+
+            // Assert
+            Assert.IsNull(exception, "interface properties are not supported?");
+            var bChanges = bTrackable.CastToIChangeTrackable();
+            var aChanges = bTrackable.Address.CastToIChangeTrackable();
+            var zChanges = bTrackable.Address.ZipCode.CastToIChangeTrackable();
+            Assert.IsTrue(bChanges.IsChanged);
+            Assert.IsTrue(aChanges.IsChanged);
+            Assert.IsTrue(zChanges.IsChanged);
+        }
+    }
+}

--- a/Source/ChangeTracking/Core.cs
+++ b/Source/ChangeTracking/Core.cs
@@ -41,15 +41,44 @@ namespace ChangeTracking
             var editableObjectInterceptor = CreateInstance(typeof(EditableObjectInterceptor<>).MakeGenericType(type), notifyParentItemCanceled);
             var complexPropertyInterceptor = CreateInstance(typeof(ComplexPropertyInterceptor<>).MakeGenericType(type), makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable);
             var collectionPropertyInterceptor = CreateInstance(typeof(CollectionPropertyInterceptor<>).MakeGenericType(type), makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable);
-            object proxy = _ProxyGenerator.CreateClassProxyWithTarget(type,
-                         new[] { typeof(IChangeTrackableInternal), typeof(IChangeTrackable<>).MakeGenericType(type), typeof(IChangeTrackingManager), typeof(IComplexPropertyTrackable), typeof(ICollectionPropertyTrackable), typeof(IEditableObject), typeof(System.ComponentModel.INotifyPropertyChanged) },
-                         target,
-                         _Options,
-                         (IInterceptor)notifyPropertyChangedInterceptor,
-                         (IInterceptor)changeTrackingInterceptor,
-                         (IInterceptor)editableObjectInterceptor,
-                         (IInterceptor)complexPropertyInterceptor,
-                         (IInterceptor)collectionPropertyInterceptor);
+            object proxy;
+
+            if (type.IsInterface)
+            {
+                proxy = _ProxyGenerator.CreateInterfaceProxyWithTarget(type,
+                    new[]
+                    {
+                        typeof(IChangeTrackableInternal), typeof(IChangeTrackable<>).MakeGenericType(type),
+                        typeof(IChangeTrackingManager), typeof(IComplexPropertyTrackable),
+                        typeof(ICollectionPropertyTrackable), typeof(IEditableObject),
+                        typeof(System.ComponentModel.INotifyPropertyChanged)
+                    },
+                    target,
+                    _Options,
+                    (IInterceptor)notifyPropertyChangedInterceptor,
+                    (IInterceptor)changeTrackingInterceptor,
+                    (IInterceptor)editableObjectInterceptor,
+                    (IInterceptor)complexPropertyInterceptor,
+                    (IInterceptor)collectionPropertyInterceptor);
+            }
+            else
+            {
+                proxy = _ProxyGenerator.CreateClassProxyWithTarget(type,
+                    new[]
+                    {
+                        typeof(IChangeTrackableInternal), typeof(IChangeTrackable<>).MakeGenericType(type),
+                        typeof(IChangeTrackingManager), typeof(IComplexPropertyTrackable),
+                        typeof(ICollectionPropertyTrackable), typeof(IEditableObject),
+                        typeof(System.ComponentModel.INotifyPropertyChanged)
+                    },
+                    target,
+                    _Options,
+                    (IInterceptor) notifyPropertyChangedInterceptor,
+                    (IInterceptor) changeTrackingInterceptor,
+                    (IInterceptor) editableObjectInterceptor,
+                    (IInterceptor) complexPropertyInterceptor,
+                    (IInterceptor) collectionPropertyInterceptor);
+            }
             ((IInterceptorSettings)notifyPropertyChangedInterceptor).IsInitialized = true;
             ((IInterceptorSettings)changeTrackingInterceptor).IsInitialized = true;
             ((IInterceptorSettings)editableObjectInterceptor).IsInitialized = true;
@@ -81,33 +110,11 @@ namespace ChangeTracking
             var editableObjectInterceptor = new EditableObjectInterceptor<T>(notifyParentListItemCanceled);
             var complexPropertyInterceptor = new ComplexPropertyInterceptor<T>(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable);
             var collectionPropertyInterceptor = new CollectionPropertyInterceptor<T>(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable);
+            object proxy;
 
-            //if (typeof(T).IsInterface)
-            //{
-            //    object proxy = _ProxyGenerator.CreateInterfaceProxyWithTarget(typeof(T),
-            //        new[]
-            //        {
-            //            typeof(IChangeTrackableInternal), typeof(IChangeTrackable<T>), typeof(IChangeTrackingManager),
-            //            typeof(IComplexPropertyTrackable), typeof(ICollectionPropertyTrackable),
-            //            typeof(IEditableObject), typeof(System.ComponentModel.INotifyPropertyChanged)
-            //        },
-            //        target,
-            //        _Options,
-            //        notifyPropertyChangedInterceptor,
-            //        changeTrackingInterceptor,
-            //        editableObjectInterceptor,
-            //        complexPropertyInterceptor,
-            //        collectionPropertyInterceptor);
-            //    notifyPropertyChangedInterceptor.IsInitialized = true;
-            //    changeTrackingInterceptor.IsInitialized = true;
-            //    editableObjectInterceptor.IsInitialized = true;
-            //    complexPropertyInterceptor.IsInitialized = true;
-            //    collectionPropertyInterceptor.IsInitialized = true;
-            //    return (T) proxy;
-            //}
-            //else
+            if (typeof(T).IsInterface)
             {
-                object proxy = _ProxyGenerator.CreateClassProxyWithTarget(typeof(T),
+                 proxy = _ProxyGenerator.CreateInterfaceProxyWithTarget(typeof(T),
                     new[]
                     {
                         typeof(IChangeTrackableInternal), typeof(IChangeTrackable<T>), typeof(IChangeTrackingManager),
@@ -126,8 +133,30 @@ namespace ChangeTracking
                 editableObjectInterceptor.IsInitialized = true;
                 complexPropertyInterceptor.IsInitialized = true;
                 collectionPropertyInterceptor.IsInitialized = true;
-                return (T) proxy;
             }
+            else
+            {
+                proxy = _ProxyGenerator.CreateClassProxyWithTarget(typeof(T),
+                    new[]
+                    {
+                        typeof(IChangeTrackableInternal), typeof(IChangeTrackable<T>), typeof(IChangeTrackingManager),
+                        typeof(IComplexPropertyTrackable), typeof(ICollectionPropertyTrackable),
+                        typeof(IEditableObject), typeof(System.ComponentModel.INotifyPropertyChanged)
+                    },
+                    target,
+                    _Options,
+                    notifyPropertyChangedInterceptor,
+                    changeTrackingInterceptor,
+                    editableObjectInterceptor,
+                    complexPropertyInterceptor,
+                    collectionPropertyInterceptor);
+                notifyPropertyChangedInterceptor.IsInitialized = true;
+                changeTrackingInterceptor.IsInitialized = true;
+                editableObjectInterceptor.IsInitialized = true;
+                complexPropertyInterceptor.IsInitialized = true;
+                collectionPropertyInterceptor.IsInitialized = true;
+            }
+            return (T)proxy;
         }
 
         public static ICollection<T> AsTrackable<T>(this System.Collections.ObjectModel.Collection<T> target) where T : class

--- a/Source/ChangeTracking/Core.cs
+++ b/Source/ChangeTracking/Core.cs
@@ -81,21 +81,53 @@ namespace ChangeTracking
             var editableObjectInterceptor = new EditableObjectInterceptor<T>(notifyParentListItemCanceled);
             var complexPropertyInterceptor = new ComplexPropertyInterceptor<T>(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable);
             var collectionPropertyInterceptor = new CollectionPropertyInterceptor<T>(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable);
-            object proxy = _ProxyGenerator.CreateClassProxyWithTarget(typeof(T),
-                new[] { typeof(IChangeTrackableInternal), typeof(IChangeTrackable<T>), typeof(IChangeTrackingManager), typeof(IComplexPropertyTrackable), typeof(ICollectionPropertyTrackable), typeof(IEditableObject), typeof(System.ComponentModel.INotifyPropertyChanged) },
-                target,
-                _Options,
-                notifyPropertyChangedInterceptor,
-                changeTrackingInterceptor,
-                editableObjectInterceptor,
-                complexPropertyInterceptor,
-                collectionPropertyInterceptor);
-            notifyPropertyChangedInterceptor.IsInitialized = true;
-            changeTrackingInterceptor.IsInitialized = true;
-            editableObjectInterceptor.IsInitialized = true;
-            complexPropertyInterceptor.IsInitialized = true;
-            collectionPropertyInterceptor.IsInitialized = true;
-            return (T)proxy;
+
+            //if (typeof(T).IsInterface)
+            //{
+            //    object proxy = _ProxyGenerator.CreateInterfaceProxyWithTarget(typeof(T),
+            //        new[]
+            //        {
+            //            typeof(IChangeTrackableInternal), typeof(IChangeTrackable<T>), typeof(IChangeTrackingManager),
+            //            typeof(IComplexPropertyTrackable), typeof(ICollectionPropertyTrackable),
+            //            typeof(IEditableObject), typeof(System.ComponentModel.INotifyPropertyChanged)
+            //        },
+            //        target,
+            //        _Options,
+            //        notifyPropertyChangedInterceptor,
+            //        changeTrackingInterceptor,
+            //        editableObjectInterceptor,
+            //        complexPropertyInterceptor,
+            //        collectionPropertyInterceptor);
+            //    notifyPropertyChangedInterceptor.IsInitialized = true;
+            //    changeTrackingInterceptor.IsInitialized = true;
+            //    editableObjectInterceptor.IsInitialized = true;
+            //    complexPropertyInterceptor.IsInitialized = true;
+            //    collectionPropertyInterceptor.IsInitialized = true;
+            //    return (T) proxy;
+            //}
+            //else
+            {
+                object proxy = _ProxyGenerator.CreateClassProxyWithTarget(typeof(T),
+                    new[]
+                    {
+                        typeof(IChangeTrackableInternal), typeof(IChangeTrackable<T>), typeof(IChangeTrackingManager),
+                        typeof(IComplexPropertyTrackable), typeof(ICollectionPropertyTrackable),
+                        typeof(IEditableObject), typeof(System.ComponentModel.INotifyPropertyChanged)
+                    },
+                    target,
+                    _Options,
+                    notifyPropertyChangedInterceptor,
+                    changeTrackingInterceptor,
+                    editableObjectInterceptor,
+                    complexPropertyInterceptor,
+                    collectionPropertyInterceptor);
+                notifyPropertyChangedInterceptor.IsInitialized = true;
+                changeTrackingInterceptor.IsInitialized = true;
+                editableObjectInterceptor.IsInitialized = true;
+                complexPropertyInterceptor.IsInitialized = true;
+                collectionPropertyInterceptor.IsInitialized = true;
+                return (T) proxy;
+            }
         }
 
         public static ICollection<T> AsTrackable<T>(this System.Collections.ObjectModel.Collection<T> target) where T : class


### PR DESCRIPTION
Hi!

I added the functionality and unit tests for supporting 
1) interface-typed properties
e.g.:
```

public class Building{
    public virtual IAddress Address {get;set;}
}
public interface IAddress{
    string Street{get;set;}
}
public class Address : IAddress{
    public virtual string Street{get;set;}
}
```

Having properties with interface types worked before, but when assigning a new instance (e.g. `building.Address = new Address()`) that instance was not wrapped in a proxy.

2) also added the support for collections with interface-elements
e.g.:

```

public class Building{
    public virtual IList<IFloors> Floors {get;set;} = new List<IFloor>();
}
public interface IFloor{
    int Number{get;set;}
}
public class Floor : IFloor{
    public virtual int Number{get;set;}
}
```
Before, when trying to call `building.AsTrackable().Floors.Add(new Floor())` you would get an exception from castle dynamic proxy