### PR TITLE
Fix documention error with usage of ChangedProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ trackable.RejectChanges();
 trackable.AcceptChanges();
 
 //If ChangeTrackingStatus is Changed it returns all changed property names, if ChangeTrackingStatus is Added or Deleted it returns all properties
-trackable.ChangedProperties();
+trackable.ChangedProperties;
 ```
 By default complex properties and collection properties will be tracked (if it can be made trackable).
 


### PR DESCRIPTION
When using it like the documentation this error is received:

```
Non-invocable member 'IChangeTrackable.ChangedProperties' cannot be used like a method.
```