### PR TITLE
Added MethodToSkip to public

### DIFF
--- a/Source/ChangeTracking.Tests/MethodToSkipTests.cs
+++ b/Source/ChangeTracking.Tests/MethodToSkipTests.cs
@@ -1,0 +1,20 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace ChangeTracking.Tests
+{
+    public class MethodToSkipTests
+    {
+        [Fact]
+        public void SkipMethods()
+        {
+            ChangeTrackingFactory.Default.MethodsToSkip.Remove(nameof(Equals));
+            ChangeTrackingFactory.Default.MethodsToSkip.Remove(nameof(GetHashCode));
+
+            var order = Helper.GetOrder();
+            Order trackable = order.AsTrackable();
+            trackable.Should().Be(order);
+            trackable.GetHashCode().Should().Be(order.GetHashCode());
+        }
+    }
+}

--- a/Source/ChangeTracking/ChangeTrackingFactory.cs
+++ b/Source/ChangeTracking/ChangeTrackingFactory.cs
@@ -50,6 +50,7 @@ namespace ChangeTracking
 
         public bool MakeComplexPropertiesTrackable { get; set; }
         public bool MakeCollectionPropertiesTrackable { get; set; }
+        public HashSet<string> MethodsToSkip { get; } = new HashSet<string>() { "Equals", "GetType", "ToString", "GetHashCode" };
 
         internal T AsTrackable<T>(T target, ChangeStatus status, Action<T> notifyParentListItemCanceled, ChangeTrackingSettings changeTrackingSettings, Graph graph) where T : class
         {
@@ -61,7 +62,7 @@ namespace ChangeTracking
             }
 
             //if T was ICollection<T> it would of gone to one of the other overloads
-            if (target as ICollection != null)
+            if (target is ICollection)
             {
                 throw new InvalidOperationException("Only IList<T>, List<T> and ICollection<T> are supported");
             }
@@ -118,7 +119,7 @@ namespace ChangeTracking
         {
             ProxyGenerationOptions CreateOptions(Type createOptionsForType) => new ProxyGenerationOptions
             {
-                Hook = new ChangeTrackingProxyGenerationHook(createOptionsForType),
+                Hook = new ChangeTrackingProxyGenerationHook(createOptionsForType, MethodsToSkip),
                 Selector = _Selector
             };
             return _Options.GetOrAdd(type, CreateOptions);

--- a/Source/ChangeTracking/ChangeTrackingProxyGenerationHook.cs
+++ b/Source/ChangeTracking/ChangeTrackingProxyGenerationHook.cs
@@ -9,18 +9,15 @@ namespace ChangeTracking
 {
     internal class ChangeTrackingProxyGenerationHook : IProxyGenerationHook
     {
-        private static HashSet<string> _MethodsToSkip;
+        private HashSet<string> _MethodsToSkip;
         private readonly Type _Type;
         private HashSet<MethodInfo> _InstanceMethodsToSkip;
 
-        static ChangeTrackingProxyGenerationHook()
+        public ChangeTrackingProxyGenerationHook(Type type, HashSet<string> methodsToSkip)
         {
-            _MethodsToSkip = new HashSet<string> { "Equals", "GetType", "ToString", "GetHashCode" };
-        }
+            _Type = type ?? throw new ArgumentNullException(nameof(type));
+            _MethodsToSkip = methodsToSkip ?? throw new ArgumentNullException(nameof(methodsToSkip));
 
-        public ChangeTrackingProxyGenerationHook(Type type)
-        {
-            _Type = type;
             const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
             _InstanceMethodsToSkip = new HashSet<MethodInfo>(type
                 .GetMethods(bindingFlags)


### PR DESCRIPTION
**What does this change:**
I need the function to pass through certain methods to the orginal target (like the funtion ToString or Equals).

Now you can add or remove method names which should be ignored.
` ChangeTrackingFactory.Default.MethodsToSkip.Remove(nameof(Equals));`