### PR TITLE
Fix derived type being tracked as base type

### DIFF
--- a/Source/ChangeTracking.Tests/InheritanceTests.cs
+++ b/Source/ChangeTracking.Tests/InheritanceTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace ChangeTracking.Tests
+{
+    public class InheritanceTests
+
+    {
+        public class Container
+        {
+            public virtual IList<Item> Items { get; set; } = new List<Item>();
+
+            public void AddItem(Item item)
+            {
+                Items.Add(item);
+            }
+        }
+
+        public  class Item
+        {
+            public Item()
+            {                
+            }
+
+            public virtual int ValueInt { get; set; }
+        }
+
+        public class ItemDerived : Item
+        {
+            public ItemDerived() :
+                base()
+            {
+
+            }
+        }
+
+        [Fact]
+        public void ItemsAdd_DerivedCollectionItemClass_AddsItemOfDerivedCollectionItemClass()
+        {
+            Container container = new Container();
+
+            var trackable = container.AsTrackable();
+
+            trackable.Items.Add(new ItemDerived());
+
+            trackable.CastToIChangeTrackable().AcceptChanges();
+
+            Assert.True(container.Items[0] is ItemDerived);
+        }
+
+    }
+}

--- a/Source/ChangeTracking/ChangeTrackingCollectionInterceptor.cs
+++ b/Source/ChangeTracking/ChangeTrackingCollectionInterceptor.cs
@@ -94,11 +94,11 @@ namespace ChangeTracking
 
         private void ItemCanceled(T item) => _WrappedTarget.CancelNew(_WrappedTarget.IndexOf(item));
 
-        public IEnumerable<T> UnchangedItems => _WrappedTarget.Cast<IChangeTrackable<T>>().Where(ct => ct.ChangeTrackingStatus == ChangeStatus.Unchanged).Cast<T>();
+        public IEnumerable<T> UnchangedItems => _WrappedTarget.Cast<IChangeTrackable>().Where(ct => ct.ChangeTrackingStatus == ChangeStatus.Unchanged).Cast<T>();
 
-        public IEnumerable<T> AddedItems => _WrappedTarget.Cast<IChangeTrackable<T>>().Where(ct => ct.ChangeTrackingStatus == ChangeStatus.Added).Cast<T>();
+        public IEnumerable<T> AddedItems => _WrappedTarget.Cast<IChangeTrackable>().Where(ct => ct.ChangeTrackingStatus == ChangeStatus.Added).Cast<T>();
 
-        public IEnumerable<T> ChangedItems => _WrappedTarget.Cast<IChangeTrackable<T>>().Where(ct => ct.ChangeTrackingStatus == ChangeStatus.Changed).Cast<T>();
+        public IEnumerable<T> ChangedItems => _WrappedTarget.Cast<IChangeTrackable>().Where(ct => ct.ChangeTrackingStatus == ChangeStatus.Changed).Cast<T>();
 
         public IEnumerable<T> DeletedItems => _DeletedItems.Select(i => i);
 

--- a/Source/ChangeTracking/ChangeTrackingInterceptor.cs
+++ b/Source/ChangeTracking/ChangeTrackingInterceptor.cs
@@ -28,7 +28,7 @@ namespace ChangeTracking
             _Properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(p => p.CanWrite).ToDictionary(pi => pi.Name);
         }
 
-        internal ChangeTrackingInterceptor(ChangeStatus status)
+        public ChangeTrackingInterceptor(ChangeStatus status)
         {
             _OriginalValueDictionary = new Dictionary<string, object>();
             _ChangedComplexOrCollectionProperties = new HashSet<string>();

--- a/Source/ChangeTracking/ComplexPropertyInterceptor.cs
+++ b/Source/ChangeTracking/ComplexPropertyInterceptor.cs
@@ -36,7 +36,7 @@ namespace ChangeTracking
             }
         }
 
-        internal ComplexPropertyInterceptor(ChangeTrackingSettings changeTrackingSettings, Graph graph)
+        public ComplexPropertyInterceptor(ChangeTrackingSettings changeTrackingSettings, Graph graph)
         {
             _ChangeTrackingSettings = changeTrackingSettings;
             _Graph = graph;

--- a/Source/ChangeTracking/EditableObjectInterceptor.cs
+++ b/Source/ChangeTracking/EditableObjectInterceptor.cs
@@ -26,7 +26,7 @@ namespace ChangeTracking
             _BeforeEditValues = new Dictionary<string, object>();
         }
 
-        internal EditableObjectInterceptor(Action<T> notifyParentItemCanceled)
+        public EditableObjectInterceptor(Action<T> notifyParentItemCanceled)
             : this()
         {
             _NotifyParentItemCanceled = notifyParentItemCanceled;

--- a/Source/ChangeTracking/IChangeTrackable.cs
+++ b/Source/ChangeTracking/IChangeTrackable.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 
 namespace ChangeTracking
 {
+
     public interface IChangeTrackable<T> : IChangeTrackable
     {
         /// <summary>

--- a/Source/ChangeTracking/NotifyPropertyChangedInterceptor.cs
+++ b/Source/ChangeTracking/NotifyPropertyChangedInterceptor.cs
@@ -24,7 +24,7 @@ namespace ChangeTracking
             _Properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance).ToDictionary(pi => pi.Name);
         }
 
-        internal NotifyPropertyChangedInterceptor(ChangeTrackingInterceptor<T> changeTrackingInterceptor)
+        public NotifyPropertyChangedInterceptor(ChangeTrackingInterceptor<T> changeTrackingInterceptor)
         {
             _PropertyChangedEventHandlers = new Dictionary<string, PropertyChangedEventHandler>();
             _PropertyChangedEventHandlersLock = new object();


### PR DESCRIPTION
Dear Joel,

#1 I took the liberty of making changes to address the issue #72 when collection item proxies created were of incorrect type. Please find PR below that addresses the issue.

#2 This is something I am not very fluent with. My gut tells me that the declaration below
`public interface IChangeTrackable<T> : IChangeTrackable
`
should be changed to

`public interface IChangeTrackable<out T> : IChangeTrackable
`(i.e. to to being contravariant).

This, however, causes conflicts with  GetOriginalValue declaration.

`TResult GetOriginalValue<TResult>(Expression<Func<T, TResult>> selector);
`
I am, unfortunately, not quite at arm lengths with contra- and co- variant interfaces and cannot clearly propose the best plant of action.  Besides this strategical idea, my changes are quite limited and all the existing tests pass.
