### PR TITLE
Original list items should not be changed to proxy items

### DIFF
--- a/Source/ChangeTracking.Tests/IChangeTrackableCollectionTests.cs
+++ b/Source/ChangeTracking.Tests/IChangeTrackableCollectionTests.cs
@@ -51,10 +51,10 @@ namespace ChangeTracking.Tests
         public void When_Calling_AsTrackable_On_Collection_All_Items_Should_Become_Trackable()
         {
             var orders = Helper.GetOrdersIList();
+            var trackable = orders.AsTrackable();
 
-            orders.AsTrackable();
-
-            orders.Should().ContainItemsAssignableTo<IChangeTrackable<Order>>();
+            orders.Should().ContainItemsAssignableTo<Order>();
+            trackable.Should().ContainItemsAssignableTo<IChangeTrackable<Order>>();
         }
 
         [Fact]
@@ -266,7 +266,7 @@ namespace ChangeTracking.Tests
             var orders = Helper.GetOrdersIList();
             var trackable = orders.AsTrackable();
 
-            var first = orders.First();
+            var first = trackable.First();
             first.Id = 963;
             first.CustomerNumber = "Testing";
             var collectionIntf = trackable.CastToIChangeTrackableCollection();
@@ -344,7 +344,7 @@ namespace ChangeTracking.Tests
             trackable.Address.Should().NotBeAssignableTo<IChangeTrackable<Address>>();
             ChangeTrackingFactory.Default.MakeComplexPropertiesTrackable = true;
         }
-               
+
         [Fact]
         public void When_Clear_Collection_Should_Work()
         {

--- a/Source/ChangeTracking/ChangeTracking.csproj
+++ b/Source/ChangeTracking/ChangeTracking.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Source/ChangeTracking/ChangeTrackingCollectionInterceptor.cs
+++ b/Source/ChangeTracking/ChangeTrackingCollectionInterceptor.cs
@@ -30,13 +30,14 @@ namespace ChangeTracking
 
         internal ChangeTrackingCollectionInterceptor(IList<T> target, ChangeTrackingSettings changeTrackingSettings, Graph graph)
         {
+            IList<T> proxies = new List<T>();
             _ChangeTrackingSettings = changeTrackingSettings;
             _Graph = graph;
             for (int i = 0; i < target.Count; i++)
             {
-                target[i] = ChangeTrackingFactory.Default.AsTrackable(target[i], ChangeStatus.Unchanged, ItemCanceled, _ChangeTrackingSettings, _Graph);
+                proxies.Add(ChangeTrackingFactory.Default.AsTrackable(target[i], ChangeStatus.Unchanged, ItemCanceled, _ChangeTrackingSettings, _Graph));
             }
-            _WrappedTarget = new ChangeTrackingBindingList<T>(target, DeleteItem, ItemCanceled, _ChangeTrackingSettings, _Graph);
+            _WrappedTarget = new ChangeTrackingBindingList<T>(proxies, DeleteItem, ItemCanceled, _ChangeTrackingSettings, _Graph);
             _DeletedItems = new List<T>();
         }
 

--- a/Source/ChangeTracking/Core.cs
+++ b/Source/ChangeTracking/Core.cs
@@ -1,5 +1,6 @@
 ﻿using ChangeTracking.Internal;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace ChangeTracking
 {
@@ -15,12 +16,12 @@ namespace ChangeTracking
             return ChangeTrackingFactory.Default.AsTrackable(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable), status);
         }
 
-        public static ICollection<T> AsTrackable<T>(this System.Collections.ObjectModel.Collection<T> target) where T : class
+        public static ICollection<T> AsTrackable<T>(this Collection<T> target) where T : class
         {
             return ChangeTrackingFactory.Default.AsTrackableCollection(target);
         }
 
-        public static ICollection<T> AsTrackable<T>(this System.Collections.ObjectModel.Collection<T> target, bool makeComplexPropertiesTrackable = true, bool makeCollectionPropertiesTrackable = true) where T : class
+        public static ICollection<T> AsTrackable<T>(this Collection<T> target, bool makeComplexPropertiesTrackable = true, bool makeCollectionPropertiesTrackable = true) where T : class
         {
             return ChangeTrackingFactory.Default.AsTrackableCollection(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable));
         }


### PR DESCRIPTION
> Breaking Change!

List items will not be proxies just by doing `.AsTrackable()`.\
You'll need to use the trackable object to access the list item proxies.

Collection tests are adjusted to reflect the new list item behavior.

Code example:
```C#
// Previously you would just type 
var myList      = new List<MyClass>();
var myClassItem = myList.First(); // --> typeof MyClass
myList.AsTrackable();
var proxyItem   = myList.First(); // --> typeof Proxy
// and now all items of myList would be proxies and tracked.

// But that system should not work like this, as the expected behavior
// is that myList items should still be MyClass and not a proxy.

// Now you can work with collections like with anything else
var myList        = new List<MyClass>();
var trackableList = myList.AsTrackable();
var myClassItem   = myList.First();        // --> typeof MyClass
var proxyItem     = trackableList.First(); // --> typeof Proxy
```

---

I updated `Microsoft.SourceLink.GitHub` to 1.1.1 because the version 1.0.0-beta-62925-02 does not exist anymore.