### PR TITLE
Added option to change collection item behavior

### DIFF
--- a/Source/ChangeTracking.Tests/ChangeTracking.Tests.csproj
+++ b/Source/ChangeTracking.Tests/ChangeTracking.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>ChangeTracking.Tests</AssemblyName>
     <RootNamespace>ChangeTracking.Tests</RootNamespace>
   </PropertyGroup>

--- a/Source/ChangeTracking.Tests/MethodToSkipTests.cs
+++ b/Source/ChangeTracking.Tests/MethodToSkipTests.cs
@@ -1,0 +1,23 @@
+using FluentAssertions;
+using Xunit;
+
+namespace ChangeTracking.Tests
+{
+    public class MethodToSkipTests
+    {
+        [Fact]
+        public void SkipMethods()
+        {
+            ChangeTrackingFactory.Default.MethodsToSkip.Remove(nameof(Equals));
+            ChangeTrackingFactory.Default.MethodsToSkip.Remove(nameof(GetHashCode));
+
+            var order = Helper.GetOrder();
+            Order trackable = order.AsTrackable();
+            //trackable.Should().Be(order);
+            trackable.GetHashCode().Should().Be(order.GetHashCode());
+            
+            ChangeTrackingFactory.Default.MethodsToSkip.Add(nameof(Equals));
+            ChangeTrackingFactory.Default.MethodsToSkip.Add(nameof(GetHashCode));
+        }
+    }
+}

--- a/Source/ChangeTracking/ChangeTracking.csproj
+++ b/Source/ChangeTracking/ChangeTracking.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <AssemblyName>ChangeTracking</AssemblyName>
     <RootNamespace>ChangeTracking</RootNamespace>
     <Version>2.2.0</Version>

--- a/Source/ChangeTracking/ChangeTracking.csproj
+++ b/Source/ChangeTracking/ChangeTracking.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Source/ChangeTracking/ChangeTrackingCollectionInterceptor.cs
+++ b/Source/ChangeTracking/ChangeTrackingCollectionInterceptor.cs
@@ -30,13 +30,28 @@ namespace ChangeTracking
 
         internal ChangeTrackingCollectionInterceptor(IList<T> target, ChangeTrackingSettings changeTrackingSettings, Graph graph)
         {
+            IList<T> proxies = new List<T>();
             _ChangeTrackingSettings = changeTrackingSettings;
             _Graph = graph;
             for (int i = 0; i < target.Count; i++)
             {
-                target[i] = ChangeTrackingFactory.Default.AsTrackable(target[i], ChangeStatus.Unchanged, ItemCanceled, _ChangeTrackingSettings, _Graph);
+                if (_ChangeTrackingSettings.MakeCollectionItemsInSourceAsProxies)
+                {
+                    target[i] = ChangeTrackingFactory.Default.AsTrackable(target[i], ChangeStatus.Unchanged, ItemCanceled, _ChangeTrackingSettings, _Graph);
+                }
+                else
+                {
+                    proxies.Add(ChangeTrackingFactory.Default.AsTrackable(target[i], ChangeStatus.Unchanged, ItemCanceled, _ChangeTrackingSettings, _Graph));
+                }
             }
-            _WrappedTarget = new ChangeTrackingBindingList<T>(target, DeleteItem, ItemCanceled, _ChangeTrackingSettings, _Graph);
+            if (_ChangeTrackingSettings.MakeCollectionItemsInSourceAsProxies)
+            {
+                _WrappedTarget = new ChangeTrackingBindingList<T>(target, DeleteItem, ItemCanceled, _ChangeTrackingSettings, _Graph);
+            }
+            else
+            {
+                _WrappedTarget = new ChangeTrackingBindingList<T>(proxies, DeleteItem, ItemCanceled, _ChangeTrackingSettings, _Graph);
+            }
             _DeletedItems = new List<T>();
         }
 

--- a/Source/ChangeTracking/ChangeTrackingFactory.cs
+++ b/Source/ChangeTracking/ChangeTrackingFactory.cs
@@ -52,6 +52,7 @@ namespace ChangeTracking
         public bool MakeComplexPropertiesTrackable { get; set; }
         public bool MakeCollectionPropertiesTrackable { get; set; }
         public bool CollectionItemsShouldNotBeProxies { get; set; }
+        public HashSet<string> MethodsToSkip { get; } = new HashSet<string>() { "Equals", "GetType", "ToString", "GetHashCode" };
 
         internal T AsTrackable<T>(T target, ChangeStatus status, Action<T> notifyParentListItemCanceled, ChangeTrackingSettings changeTrackingSettings, Graph graph) where T : class
         {
@@ -63,7 +64,7 @@ namespace ChangeTracking
             }
 
             //if T was ICollection<T> it would of gone to one of the other overloads
-            if (target as ICollection != null)
+            if (target is ICollection)
             {
                 throw new InvalidOperationException("Only IList<T>, List<T> and ICollection<T> are supported");
             }
@@ -120,7 +121,7 @@ namespace ChangeTracking
         {
             ProxyGenerationOptions CreateOptions(Type createOptionsForType) => new ProxyGenerationOptions
             {
-                Hook = new ChangeTrackingProxyGenerationHook(createOptionsForType),
+                Hook = new ChangeTrackingProxyGenerationHook(createOptionsForType, MethodsToSkip),
                 Selector = _Selector
             };
             return _Options.GetOrAdd(type, CreateOptions);

--- a/Source/ChangeTracking/ChangeTrackingFactory.cs
+++ b/Source/ChangeTracking/ChangeTrackingFactory.cs
@@ -24,12 +24,13 @@ namespace ChangeTracking
 
         public static ChangeTrackingFactory Default { get; }
 
-        public ChangeTrackingFactory() : this(makeComplexPropertiesTrackable: true, makeCollectionPropertiesTrackable: true) { }
+        public ChangeTrackingFactory() : this(makeComplexPropertiesTrackable: true, makeCollectionPropertiesTrackable: true, makeCollectionItemsInSourceAsProxies: true) { }
 
-        public ChangeTrackingFactory(bool makeComplexPropertiesTrackable, bool makeCollectionPropertiesTrackable)
+        public ChangeTrackingFactory(bool makeComplexPropertiesTrackable, bool makeCollectionPropertiesTrackable, bool makeCollectionItemsInSourceAsProxies)
         {
             MakeComplexPropertiesTrackable = makeComplexPropertiesTrackable;
             MakeCollectionPropertiesTrackable = makeCollectionPropertiesTrackable;
+            CollectionItemsShouldNotBeProxies = makeCollectionItemsInSourceAsProxies;
 
             _ProxyGenerator = new ProxyGenerator();
             _Selector = new ChangeTrackingInterceptorSelector();
@@ -40,16 +41,17 @@ namespace ChangeTracking
 
         public T AsTrackable<T>(T target, ChangeStatus status = ChangeStatus.Unchanged) where T : class
         {
-            return AsTrackable(target, new ChangeTrackingSettings(MakeComplexPropertiesTrackable, MakeCollectionPropertiesTrackable), status);
+            return AsTrackable(target, new ChangeTrackingSettings(MakeComplexPropertiesTrackable, MakeCollectionPropertiesTrackable, CollectionItemsShouldNotBeProxies), status);
         }
 
         public ICollection<T> AsTrackableCollection<T>(ICollection<T> target) where T : class
         {
-            return AsTrackableCollection(target, new ChangeTrackingSettings(MakeComplexPropertiesTrackable, MakeCollectionPropertiesTrackable));
+            return AsTrackableCollection(target, new ChangeTrackingSettings(MakeComplexPropertiesTrackable, MakeCollectionPropertiesTrackable, CollectionItemsShouldNotBeProxies));
         }
 
         public bool MakeComplexPropertiesTrackable { get; set; }
         public bool MakeCollectionPropertiesTrackable { get; set; }
+        public bool CollectionItemsShouldNotBeProxies { get; set; }
 
         internal T AsTrackable<T>(T target, ChangeStatus status, Action<T> notifyParentListItemCanceled, ChangeTrackingSettings changeTrackingSettings, Graph graph) where T : class
         {

--- a/Source/ChangeTracking/ChangeTrackingProxyGenerationHook.cs
+++ b/Source/ChangeTracking/ChangeTrackingProxyGenerationHook.cs
@@ -9,18 +9,14 @@ namespace ChangeTracking
 {
     internal class ChangeTrackingProxyGenerationHook : IProxyGenerationHook
     {
-        private static HashSet<string> _MethodsToSkip;
+        private HashSet<string> _MethodsToSkip;
         private readonly Type _Type;
         private HashSet<MethodInfo> _InstanceMethodsToSkip;
 
-        static ChangeTrackingProxyGenerationHook()
+        public ChangeTrackingProxyGenerationHook(Type type, HashSet<string> methodsToSkip)
         {
-            _MethodsToSkip = new HashSet<string> { "Equals", "GetType", "ToString", "GetHashCode" };
-        }
-
-        public ChangeTrackingProxyGenerationHook(Type type)
-        {
-            _Type = type;
+            _Type = type ?? throw new ArgumentNullException(nameof(type));
+            _MethodsToSkip = methodsToSkip ?? throw new ArgumentNullException(nameof(methodsToSkip));
             const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
             _InstanceMethodsToSkip = new HashSet<MethodInfo>(type
                 .GetMethods(bindingFlags)

--- a/Source/ChangeTracking/Core.cs
+++ b/Source/ChangeTracking/Core.cs
@@ -1,5 +1,6 @@
 ﻿using ChangeTracking.Internal;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace ChangeTracking
 {
@@ -10,19 +11,19 @@ namespace ChangeTracking
             return ChangeTrackingFactory.Default.AsTrackable(target);
         }
 
-        public static T AsTrackable<T>(this T target, ChangeStatus status = ChangeStatus.Unchanged, bool makeComplexPropertiesTrackable = true, bool makeCollectionPropertiesTrackable = true) where T : class
+        public static T AsTrackable<T>(this T target, ChangeStatus status = ChangeStatus.Unchanged, bool makeComplexPropertiesTrackable = true, bool makeCollectionPropertiesTrackable = true, bool makeCollectionItemsInSourceAsProxies = true) where T : class
         {
-            return ChangeTrackingFactory.Default.AsTrackable(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable), status);
+            return ChangeTrackingFactory.Default.AsTrackable(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable, makeCollectionItemsInSourceAsProxies), status);
         }
 
-        public static ICollection<T> AsTrackable<T>(this System.Collections.ObjectModel.Collection<T> target) where T : class
+        public static ICollection<T> AsTrackable<T>(this Collection<T> target) where T : class
         {
             return ChangeTrackingFactory.Default.AsTrackableCollection(target);
         }
 
-        public static ICollection<T> AsTrackable<T>(this System.Collections.ObjectModel.Collection<T> target, bool makeComplexPropertiesTrackable = true, bool makeCollectionPropertiesTrackable = true) where T : class
+        public static ICollection<T> AsTrackable<T>(this Collection<T> target, bool makeComplexPropertiesTrackable = true, bool makeCollectionPropertiesTrackable = true, bool makeCollectionItemsInSourceAsProxies = true) where T : class
         {
-            return ChangeTrackingFactory.Default.AsTrackableCollection(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable));
+            return ChangeTrackingFactory.Default.AsTrackableCollection(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable, makeCollectionItemsInSourceAsProxies));
         }
 
         public static ICollection<T> AsTrackable<T>(this ICollection<T> target) where T : class
@@ -30,9 +31,9 @@ namespace ChangeTracking
             return ChangeTrackingFactory.Default.AsTrackableCollection(target);
         }
 
-        public static ICollection<T> AsTrackable<T>(this ICollection<T> target, bool makeComplexPropertiesTrackable, bool makeCollectionPropertiesTrackable) where T : class
+        public static ICollection<T> AsTrackable<T>(this ICollection<T> target, bool makeComplexPropertiesTrackable, bool makeCollectionPropertiesTrackable, bool makeCollectionItemsInSourceAsProxies) where T : class
         {
-            return ChangeTrackingFactory.Default.AsTrackableCollection(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable));
+            return ChangeTrackingFactory.Default.AsTrackableCollection(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable, makeCollectionItemsInSourceAsProxies));
         }
 
         public static IList<T> AsTrackable<T>(this List<T> target) where T : class
@@ -40,9 +41,9 @@ namespace ChangeTracking
             return (IList<T>)ChangeTrackingFactory.Default.AsTrackableCollection(target);
         }
 
-        public static IList<T> AsTrackable<T>(this List<T> target, bool makeComplexPropertiesTrackable, bool makeCollectionPropertiesTrackable) where T : class
+        public static IList<T> AsTrackable<T>(this List<T> target, bool makeComplexPropertiesTrackable, bool makeCollectionPropertiesTrackable, bool makeCollectionItemsInSourceAsProxies) where T : class
         {
-            return (IList<T>)ChangeTrackingFactory.Default.AsTrackableCollection(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable));
+            return (IList<T>)ChangeTrackingFactory.Default.AsTrackableCollection(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable, makeCollectionItemsInSourceAsProxies));
         }
 
         public static IList<T> AsTrackable<T>(this IList<T> target) where T : class
@@ -50,9 +51,9 @@ namespace ChangeTracking
             return (IList<T>)ChangeTrackingFactory.Default.AsTrackableCollection(target);
         }
 
-        public static IList<T> AsTrackable<T>(this IList<T> target, bool makeComplexPropertiesTrackable, bool makeCollectionPropertiesTrackable) where T : class
+        public static IList<T> AsTrackable<T>(this IList<T> target, bool makeComplexPropertiesTrackable, bool makeCollectionPropertiesTrackable, bool makeCollectionItemsInSourceAsProxies) where T : class
         {
-            return (IList<T>)ChangeTrackingFactory.Default.AsTrackableCollection(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable));
+            return (IList<T>)ChangeTrackingFactory.Default.AsTrackableCollection(target, new ChangeTrackingSettings(makeComplexPropertiesTrackable, makeCollectionPropertiesTrackable, makeCollectionItemsInSourceAsProxies));
         }
     }
 }

--- a/Source/ChangeTracking/Internal/ChangeTrackingSettings.cs
+++ b/Source/ChangeTracking/Internal/ChangeTrackingSettings.cs
@@ -2,13 +2,15 @@
 {
     internal readonly struct ChangeTrackingSettings
     {
-        internal ChangeTrackingSettings(bool makeComplexPropertiesTrackable, bool makeCollectionPropertiesTrackable)
+        internal ChangeTrackingSettings(bool makeComplexPropertiesTrackable, bool makeCollectionPropertiesTrackable, bool makeCollectionItemsInSourceAsProxies)
         {
             MakeComplexPropertiesTrackable = makeComplexPropertiesTrackable;
             MakeCollectionPropertiesTrackable = makeCollectionPropertiesTrackable;
+            MakeCollectionItemsInSourceAsProxies = makeCollectionItemsInSourceAsProxies;
         }
 
         internal bool MakeComplexPropertiesTrackable { get; }
         internal bool MakeCollectionPropertiesTrackable { get; }
+        internal bool MakeCollectionItemsInSourceAsProxies { get; }
     }
 }


### PR DESCRIPTION
Added a new option `CollectionItemsShouldNotBeProxies` which is by default `true` (to not break system already using this).\
This option allows users to choose the behavior of collection item tracking.

With this option true, all items of a collection are being converted to proxies on `.AsTrackable()` like bevor.\
But if you set the option to `false`, only the collection items in the trackable object are beeing proxied. The original items in the source list will stay the same class and not be proxied - like the rest of objects with tracking.

```
ChangeTrackingFactory.Default.CollectionItemsShouldNotBeProxies = true; // Old System

var myList        = new List<MyClass>();
var myClassItem   = myList.First();        // --> typeof myClass
var trackableList = myList.AsTrackable();

var myClassItem2  = myList.First();        // --> typeof Proxy
var proxyItem     = trackableList.First(); // --> typeof Proxy
```
```
ChangeTrackingFactory.Default.CollectionItemsShouldNotBeProxies = false; // New System

var myList        = new List<MyClass>();
var myClassItem   = myList.First();        // --> typeof myClass
var trackableList = myList.AsTrackable();

myClassItem       = myList.First();        // --> typeof myClass
var proxyItem     = trackableList.First(); // --> typeof Proxy
```