### PR TITLE
Make ICollectionPropertyTrackable public

### DIFF
--- a/Source/ChangeTracking/ICollectionPropertyTrackable.cs
+++ b/Source/ChangeTracking/ICollectionPropertyTrackable.cs
@@ -2,8 +2,11 @@ using System.Collections.Generic;
 
 namespace ChangeTracking
 {
-    internal interface ICollectionPropertyTrackable
+    public interface ICollectionPropertyTrackable
     {
+        /// <summary>
+        /// Gets the list of all trackable collection properties.
+        /// </summary>
         IEnumerable<object> CollectionPropertyTrackables { get; }
     }
 }


### PR DESCRIPTION
There is currently no way to get all trackable collection properties from a proxy.

I'd like to have access to those and therefore made the `ICollectionPropertyTrackable` interface public with this pull request.